### PR TITLE
add: markdown preview to /notes/new page

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,55 +1,19 @@
 <template>
-  <div>
-    <Nuxt />
+  <div class="h-100 d-flex flex-column">
+    <b-navbar>
+      <b-navbar-nav>
+        <b-nav-item to="/notes/new">/notes/new</b-nav-item>
+      </b-navbar-nav>
+    </b-navbar>
+    <Nuxt class="flex-fill" />
   </div>
 </template>
 
 <style>
-html {
-  font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 16px;
-  word-spacing: 1px;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  box-sizing: border-box;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-}
-
-.button--green {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #3b8070;
-  color: #3b8070;
-  text-decoration: none;
-  padding: 10px 30px;
-}
-
-.button--green:hover {
-  color: #fff;
-  background-color: #3b8070;
-}
-
-.button--grey {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #35495e;
-  color: #35495e;
-  text-decoration: none;
-  padding: 10px 30px;
-  margin-left: 15px;
-}
-
-.button--grey:hover {
-  color: #fff;
-  background-color: #35495e;
+html,
+body,
+#__nuxt,
+#__layout {
+  height: 100%;
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,7 +17,12 @@ export default {
   },
 
   // Global CSS (https://go.nuxtjs.dev/config-css)
-  css: [],
+  css: [
+    {
+      src: '~/node_modules/highlight.js/styles/atom-one-light.css',
+      lang: 'css',
+    },
+  ],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [],
@@ -37,7 +42,13 @@ export default {
   modules: [
     // https://go.nuxtjs.dev/bootstrap
     'bootstrap-vue/nuxt',
+    '@nuxtjs/markdownit',
   ],
+
+  markdownit: {
+    injected: true,
+    use: ['markdown-it-highlightjs'],
+  },
 
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,6 +1954,25 @@
         "eslint-loader": "^4.0.2"
       }
     },
+    "@nuxtjs/markdownit": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/markdownit/-/markdownit-1.2.10.tgz",
+      "integrity": "sha512-MWvrVrQNxpnfN4bUUH6mCe7wjpDLj1MUij84u4Rfd4vw+koaj1OzX63Q7MAdrDtFT6Li6yn3YNpq7oJQKmyyPQ==",
+      "requires": {
+        "@nuxtjs/markdownit-loader": "^1.1.1",
+        "raw-loader": "^4.0.1"
+      }
+    },
+    "@nuxtjs/markdownit-loader": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/markdownit-loader/-/markdownit-loader-1.1.1.tgz",
+      "integrity": "sha512-ijbEL5QOTRGuykwpikxaanxv5QntRiGYPtBDFvvdhoVNpsfbvROk1QnxCd2tMaYo6zKtpjFQS1RXcluwn5oTXg==",
+      "requires": {
+        "highlight.js": "^9.12.0",
+        "loader-utils": "^1.1.0",
+        "markdown-it": "^8.3.1"
+      }
+    },
     "@nuxtjs/stylelint-module": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/stylelint-module/-/stylelint-module-4.0.0.tgz",
@@ -7243,6 +7262,11 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "highlight.js": {
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8159,6 +8183,14 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -8241,6 +8273,11 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -8389,6 +8426,41 @@
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
+    },
+    "markdown-it-highlightjs": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.3.1.tgz",
+      "integrity": "sha512-T9L+37CC+H/aQWHbHCpmo6FvSH2imqXYjZj/Tj064UmPn0aCne/bAtSORo6W5x7BdLIWwbTR20xrdlKDAq0M6w==",
+      "requires": {
+        "highlight.js": "^10.2.0",
+        "lodash.flow": "^3.5.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.3.2",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
+          "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw=="
+        }
+      }
+    },
     "markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -8427,6 +8499,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -10904,6 +10981,37 @@
         "unpipe": "1.0.0"
       }
     },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "rc9": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-1.1.0.tgz",
@@ -13089,6 +13197,11 @@
       "version": "0.7.22",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
       "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.11.5",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@nuxt/typescript-runtime": "^2.0.0",
+    "@nuxtjs/markdownit": "^1.2.10",
     "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.17.3",
     "core-js": "^3.6.5",
     "firebase": "^8.0.2",
+    "markdown-it-highlightjs": "^3.3.1",
     "nuxt": "^2.14.6"
   },
   "devDependencies": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,28 +1,5 @@
 <template>
-  <div class="container">
-    <div>
-      <Logo />
-      <h1 class="title">hiden-no-tare</h1>
-      <div class="links">
-        <a
-          href="https://nuxtjs.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="button--green"
-        >
-          Documentation
-        </a>
-        <a
-          href="https://github.com/nuxt/nuxt.js"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="button--grey"
-        >
-          GitHub
-        </a>
-      </div>
-    </div>
-  </div>
+  <div></div>
 </template>
 
 <script lang="ts">
@@ -30,36 +7,3 @@ import Vue from 'vue'
 
 export default Vue.extend({})
 </script>
-
-<style>
-.container {
-  margin: 0 auto;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
-
-.title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  display: block;
-  font-weight: 300;
-  font-size: 100px;
-  color: #35495e;
-  letter-spacing: 1px;
-}
-
-.subtitle {
-  font-weight: 300;
-  font-size: 42px;
-  color: #526488;
-  word-spacing: 5px;
-  padding-bottom: 15px;
-}
-
-.links {
-  padding-top: 15px;
-}
-</style>

--- a/pages/notes/new.vue
+++ b/pages/notes/new.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="container">
+    <b-form class="d-flex flex-column h-100" @submit.prevent="onPostClick">
+      <b-form-input
+        v-model="title"
+        placeholder="Title"
+        required
+        class="mb-3"
+      ></b-form-input>
+      <b-row class="flex-fill">
+        <b-col class="pr-0">
+          <b-form-textarea
+            v-model="content"
+            class="h-100"
+            placeholder="Content"
+          ></b-form-textarea>
+        </b-col>
+        <b-col class="pl-0 h-100">
+          <div
+            class="preview py-2 px-2 mr-3 border rounded"
+            v-html="$md.render(content)"
+          ></div>
+        </b-col>
+      </b-row>
+      <div>
+        <b-button type="submit" variant="success" class="my-2 float-right"
+          >Post</b-button
+        >
+      </div>
+    </b-form>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({
+  data() {
+    return {
+      title: '',
+      content: '',
+    }
+  },
+  methods: {
+    onPostClick() {
+      console.log('call onPostClick')
+    },
+  },
+})
+</script>
+
+<style scoped>
+.preview {
+  overflow: auto;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+</style>


### PR DESCRIPTION
notes/new page を作って markdown preview ができるように実装。
下の記事が参考になった。
https://www.samuelcoe.com/blog/18-02-25-nuxt-hightlight/
height 100% かつ overflow auto にすることに手こずった。
height 100% の  wrapper に対して、position absolute, top 0, right 0, bottom 0, left 0 にすると上手くいった。

view と viewmodel だけの実装になっているので、これから vuex と firestore を用いて model を実装していく。
vuefire を使うのがいいらしい。
